### PR TITLE
feat: Implement pagination and filtering for workout list

### DIFF
--- a/GymLog/settings.py
+++ b/GymLog/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework', # For DRF
     'rest_framework_simplejwt', # For JWT authentication
+    'django_filters', # For filtering support in DRF
     'users',
     'workouts',
 ]
@@ -112,6 +113,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
+
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10, # Number of items per page
 
     'DEFAULT_PARSER_CLASSES': [
         'rest_framework.parsers.JSONParser',

--- a/workouts/filters.py
+++ b/workouts/filters.py
@@ -1,0 +1,15 @@
+import django_filters
+from .models import Workout
+
+class WorkoutFilter(django_filters.FilterSet):
+    # Allow filtering by date and a date range
+    date = django_filters.DateFilter(field_name='date', lookup_expr='exact')
+    date_after = django_filters.DateFilter(field_name='date', lookup_expr='gte')
+    date_before = django_filters.DateFilter(field_name='date', lookup_expr='lte')
+    
+    # Allow case-insensitive search on exercise name
+    exercise_name = django_filters.CharFilter(field_name='exercise_name', lookup_expr='icontains')
+    
+    class Meta:
+        model = Workout
+        fields = ['date', 'date_after', 'date_before', 'exercise_name']

--- a/workouts/views.py
+++ b/workouts/views.py
@@ -6,9 +6,12 @@ from .models import Workout, Category, Analytics
 from rest_framework.views import APIView
 from datetime import date, timedelta
 from django.db.models import Sum, Max, F
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework import status
 from .serializers import WorkoutSerializer, CategorySerializer, AnalyticsSerializer
+from django_filters.rest_framework import DjangoFilterBackend
+from .filters import WorkoutFilter
 
 # Category Views 
 class CategoryListCreateView(generics.ListCreateAPIView):
@@ -35,6 +38,9 @@ class WorkoutListCreateView(generics.ListCreateAPIView):
     serializer_class = WorkoutSerializer
     permission_classes = [permissions.IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
+    pagination_class = PageNumberPagination 
+    filter_backends = [DjangoFilterBackend]  # Add this line
+    filterset_class = WorkoutFilter
 
     def get_queryset(self):
         """


### PR DESCRIPTION
This commit adds key API enhancements to improve performance and user experience.

- **Pagination:** The workout list endpoint is now paginated, limiting results to 10 per page and providing links to navigate through the dataset.
- **Filtering:** Added a new  that allows users to query workouts by Sun Aug 31 21:40:08 EAST 2025, , , and .